### PR TITLE
gh-37/redirect-after-login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,21 @@
 class ApplicationController < ActionController::Base
+  before_action :store_user_location!, if: :storable_location?
+
+  private
+
+  def storable_location?
+    request.get? && 
+    is_navigational_format? && 
+    !devise_controller? && 
+    !request.xhr? && 
+    !turbo_frame_request?
+  end
+
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
+  end
+
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || super
+  end
 end


### PR DESCRIPTION
closes #37 

adds logic to remember route before login to reroute them back after login